### PR TITLE
Reduce Falco Fan Speeds To Reduce Noise

### DIFF
--- a/common/thermal.c
+++ b/common/thermal.c
@@ -44,7 +44,7 @@ test_export_static struct thermal_config_t
 	{THERMAL_CONFIG_NO_FLAG, {THERMAL_THRESHOLD_DISABLE_ALL} },
 };
 test_export_static const int fan_speed[THERMAL_FAN_STEPS + 1] =
-{2700, 3000, 3300, 3600, 3900, 4200, 4500, 5000};
+{1400, 1600, 1800, 2000, 2500, 3000, 3500, 5000};
 #endif
 #ifdef BOARD_peppy				/* DON'T DO THIS */
 test_export_static struct thermal_config_t


### PR DESCRIPTION
As requested and tested by paviluf.

Falco's fans are very noisy, so the speed steps have been adjusted to minimize noise. Steps were recommended by paviluf as ones he had used via ectool for months. Other users have also complained about the noise from Falco's fans.

http://h30434.www3.hp.com/t5/Notebook-Operating-System-and-Recovery/HP-Chromebook-14-fans-are-constantly-running-and-are-too/td-p/3444871

The change is to Falco-specific code and has no effect on Peppy, which can still be built from this source.