### PR TITLE
Fixed Systemd-boot.

### DIFF
--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -449,17 +449,6 @@ static void keyboard_enable(int enable)
 		CPRINTF("[%T KB enable]\n");
 	} else if (keyboard_enabled && !enable) {
 		CPRINTF("[%T KB disable]\n");
-		reset_rate_and_delay();
-		typematic_len = 0;  /* stop typematic */
-
-		/* Disable keystroke as well in case the BIOS doesn't
-		 * disable keystroke where repeated strokes are queued
-		 * before kernel initializes keyboard. Hence the kernel
-		 * is unable to get stable CTR read (get key codes
-		 * instead).
-		 */
-		keystroke_enable(0);
-		keyboard_clear_buffer();
 	}
 	keyboard_enabled = enable;
 }
@@ -709,12 +698,15 @@ static int handle_keyboard_command(uint8_t command, uint8_t *output)
 
 	case I8042_DIS_KB:
 		update_ctl_ram(0, read_ctl_ram(0) | I8042_KBD_DIS);
+		reset_rate_and_delay();
+		typematic_len = 0;  /* stop typematic */
+		keyboard_clear_buffer();
 		break;
 
 	case I8042_ENA_KB:
 		update_ctl_ram(0, read_ctl_ram(0) & ~I8042_KBD_DIS);
-        keystroke_enable(1);
-        keyboard_clear_buffer();
+        	keystroke_enable(1);
+        	keyboard_clear_buffer();
 		break;
 
 	case I8042_READ_OUTPUT_PORT:


### PR DESCRIPTION
This prevents problematic disabling of the keystrokes by making it so that 0xAD can't disable keystrokes, which is more like actual PS/2 behavior.

Also cleans up keyboard controller enable/disable code. I have found no regressions.

This change is needed on HSW, BDW, and BYT to resolve the keyboard not working in systemd-boot.