### PR TITLE
CTRL+ALT+DELETE Implementation.

### DIFF
--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -315,6 +315,9 @@ static enum scancode_set_list acting_code_set(enum scancode_set_list set)
 	return set;
 }
 
+static int8_t lctrl_down = 0;
+static int8_t lalt_down = 0;
+
 /**
  * Return the make or break code bytes for the active scancode set.
  *
@@ -383,14 +386,23 @@ static enum ec_error_list matrix_callback(int8_t row, int8_t col,
 		keyboard_special(scancode_set1[row][col]);
 
 	code_set = acting_code_set(code_set);
+	
+	if (row == 2 && col == 0)
+		lctrl_down = pressed;
+	if (row == 6 && col == 10)
+		lalt_down = pressed;
 
 	switch (code_set) {
 	case SCANCODE_SET_1:
 		make_code = scancode_set1[row][col];
+		if (lctrl_down && lalt_down && make_code == 0x000e)
+			make_code = 0xe053;
 		break;
 
 	case SCANCODE_SET_2:
 		make_code = scancode_set2[row][col];
+		if (lctrl_down && lalt_down && make_code == 0x0066)
+			make_code = 0xe071;
 		break;
 
 	default:


### PR DESCRIPTION
Provides CTRL+ALT+DELETE function on Chromebooks with ChromeEC via Left CTRL + Left ALT + Backspace.