### PR TITLE
Stabilize CTR Read For Linux.

### DIFF
--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -711,7 +711,10 @@ static int handle_keyboard_command(uint8_t command, uint8_t *output)
 
 	switch (command) {
 	case I8042_READ_CMD_BYTE:
+		keyboard_clear_buffer();
+		keystroke_enable(0);
 		output[out_len++] = read_ctl_ram(0);
+		keystroke_enable(1);
 		break;
 
 	case I8042_WRITE_CMD_BYTE:


### PR DESCRIPTION
Fixes nonfunctional keyboard after key spam between bootloader and i8042 init.

Linux needs a stable CTR read when i8042 is initialized or the PS/2 keyboard does not work.

https://github.com/torvalds/linux/commit/ee1e82cee5e463a885d3c71acb2c769490e6927f

Fix works by disabling keystrokes when CTR (PS/2 Controller Configuration Byte) is written then re-enabling them, giving i8042 enough time to get a stable read (same read twice in a row).

Previous fix was non-functional on custom firmwares and was removed in "Fixed Systemd-boot." This new fix replaces it and works correctly on custom firmware.