### PR TITLE
Firmware cyan 7287.57.b

### DIFF
--- a/board/cyan/board.c
+++ b/board/cyan/board.c
@@ -204,18 +204,7 @@ void lid_angle_peripheral_enable(int enable)
 		keyboard_scan_enable(1, KB_SCAN_DISABLE_LID_ANGLE);
 		track_pad_enable(1);
 	} else {
-		/*
-		 * Ensure chipset is off before disabling keyboard. When chipset
-		 * is on, EC keeps keyboard enabled and the AP decides when to
-		 * ignore keys based on its more accurate lid angle calculation.
-		 *
-		 * TODO(crosbug.com/p/43695): Remove this check once we have a
-		 * host command that can inform EC when we are entering or
-		 * exiting tablet mode in S0. Also, add this check back to the
-		 * function lid_angle_update in lid_angle.c
-		 */
-		if (!chipset_in_state(CHIPSET_STATE_ON))
-			keyboard_scan_enable(0, KB_SCAN_DISABLE_LID_ANGLE);
+		keyboard_scan_enable(0, KB_SCAN_DISABLE_LID_ANGLE);
 		track_pad_enable(0);
 	}
 }

--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -692,6 +692,8 @@ static int handle_keyboard_command(uint8_t command, uint8_t *output)
 
 	case I8042_ENA_KB:
 		update_ctl_ram(0, read_ctl_ram(0) & ~I8042_KBD_DIS);
+		keystroke_enable(1);
+		keyboard_clear_buffer();
 		break;
 
 	case I8042_READ_OUTPUT_PORT:

--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -691,7 +691,10 @@ static int handle_keyboard_command(uint8_t command, uint8_t *output)
 
 	switch (command) {
 	case I8042_READ_CMD_BYTE:
+		keyboard_clear_buffer();
+		keystroke_enable(0);
 		output[out_len++] = read_ctl_ram(0);
+		keystroke_enable(1);
 		break;
 
 	case I8042_WRITE_CMD_BYTE:

--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -428,17 +428,6 @@ static void keyboard_enable(int enable)
 		CPRINTS("KB enable");
 	} else if (keyboard_enabled && !enable) {
 		CPRINTS("KB disable");
-		reset_rate_and_delay();
-		typematic_len = 0;  /* stop typematic */
-
-		/* Disable keystroke as well in case the BIOS doesn't
-		 * disable keystroke where repeated strokes are queued
-		 * before kernel initializes keyboard. Hence the kernel
-		 * is unable to get stable CTR read (get key codes
-		 * instead).
-		 */
-		keystroke_enable(0);
-		keyboard_clear_buffer();
 	}
 	keyboard_enabled = enable;
 }
@@ -688,6 +677,9 @@ static int handle_keyboard_command(uint8_t command, uint8_t *output)
 
 	case I8042_DIS_KB:
 		update_ctl_ram(0, read_ctl_ram(0) | I8042_KBD_DIS);
+		reset_rate_and_delay();
+		typematic_len = 0;  /* stop typematic */
+		keyboard_clear_buffer();
 		break;
 
 	case I8042_ENA_KB:

--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -303,6 +303,11 @@ static void scancode_bytes(uint16_t make_code, int8_t pressed,
 	}
 }
 
+
+static int8_t lctrl_down = 0;
+static int8_t lalt_down = 0;
+static int8_t cad_pressed = 0;
+
 static enum ec_error_list matrix_callback(int8_t row, int8_t col,
 					  int8_t pressed,
 					  enum scancode_set_list code_set,
@@ -320,14 +325,33 @@ static enum ec_error_list matrix_callback(int8_t row, int8_t col,
 		keyboard_special(scancode_set1[row][col]);
 
 	code_set = acting_code_set(code_set);
+	
+	if (row == 2 && col == 0)
+		lctrl_down = pressed;
+	if (row == 6 && col == 10)
+		lalt_down = pressed;
 
 	switch (code_set) {
 	case SCANCODE_SET_1:
 		make_code = scancode_set1[row][col];
+		if (lctrl_down && lalt_down && pressed && make_code == 0x000e) {
+			cad_pressed = 1;
+			make_code = 0xe053;
+		} else if (cad_pressed && make_code == 0x000e) {
+			cad_pressed = 0;
+			make_code = 0xe053;
+		}
 		break;
 
 	case SCANCODE_SET_2:
 		make_code = scancode_set2[row][col];
+		if (lctrl_down && lalt_down && pressed && make_code == 0x0066) {
+			cad_pressed = 1;
+			make_code = 0xe071;
+		} else if (cad_pressed && make_code == 0x0066) {
+			cad_pressed = 0;
+			make_code = 0xe071;
+		}
 		break;
 
 	default:

--- a/util/build.mk
+++ b/util/build.mk
@@ -6,8 +6,8 @@
 # Host tools build
 #
 
-host-util-bin=ectool lbplay stm32mon ec_sb_firmware_update lbcc
-build-util-bin=ec_uartd iteflash
+host-util-bin=ectool
+build-util-bin=
 
 comm-objs=$(util-lock-objs:%=lock/%) comm-host.o comm-dev.o
 comm-objs+=comm-lpc.o comm-i2c.o misc_util.o

--- a/util/getversion.sh
+++ b/util/getversion.sh
@@ -54,7 +54,7 @@ echo "#define CROS_EC_VERSION32 \"${ver:0:31}\""
 echo "/* Sub-fields for use in Makefile.rules and to form build info string"
 echo " * in common/version.c. */"
 echo "#define VERSION \"${ver}\""
-echo "#define BUILDER \"${USER}@`hostname`\""
+echo "#define BUILDER \"MrChromebox\""
 
 echo "/* Author date of last commit, in case compile-time is not used. */"
 echo "#ifndef DATE"


### PR DESCRIPTION
It merges the latest commits from upstream, and also allows the keyboard to be disabled when on tablet mode. (Previously only the touchpad was being disabled)
