### PR TITLE
Backport fix for keyboard disabling function

### DIFF
--- a/common/keyboard_8042.c
+++ b/common/keyboard_8042.c
@@ -406,7 +406,7 @@ static void set_typematic_key(const uint8_t *scan_code, int32_t len)
 	typematic_len = len;
 }
 
-static void clear_typematic_key(void)
+void clear_typematic_key(void)
 {
 	typematic_len = 0;
 }

--- a/common/keyboard_mkbp.c
+++ b/common/keyboard_mkbp.c
@@ -188,6 +188,9 @@ void keyboard_send_battery_key(void)
 		keyboard_fifo_add(state);
 }
 
+void clear_typematic_key(void)
+{ }
+
 /*****************************************************************************/
 /* Host commands */
 

--- a/common/keyboard_scan.c
+++ b/common/keyboard_scan.c
@@ -119,6 +119,7 @@ void keyboard_scan_enable(int enable, enum kb_scan_disable_masks mask)
 	} else if (disable_scanning_mask && !old_disable_scanning) {
 		keyboard_raw_drive_column(KEYBOARD_COLUMN_NONE);
 		keyboard_clear_buffer();
+		clear_typematic_key();
 	}
 }
 

--- a/include/keyboard_scan.h
+++ b/include/keyboard_scan.h
@@ -91,6 +91,11 @@ enum kb_scan_disable_masks {
  * @param mask Disable reasons from kb_scan_disable_masks
  */
 void keyboard_scan_enable(int enable, enum kb_scan_disable_masks mask);
+
+/**
+ * Clears typematic key
+ */
+void clear_typematic_key(void);
 #else
 static inline void keyboard_scan_enable(int enable,
 		enum kb_scan_disable_masks mask) { }


### PR DESCRIPTION
Previous to this commit, disabling the keyboard (ex: when entering on tablet mode) with a key pressed would cause the key to be kept pressed until enabling the keyboard again.