### PR TITLE
fizz: power: Add After G3 State handling/command

### DIFF
--- a/board/fizz/board.h
+++ b/board/fizz/board.h
@@ -66,6 +66,13 @@
 /* EC console commands */
 #define CONFIG_CMD_BUTTON
 
+/* Enable After G3 State. */
+#define CONFIG_AFTER_G3_STATE
+/* RO for FIZZ only supports AP_OFF as OFF flag. */
+#define CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG
+/* RO for FIZZ is bugged when jumping from RW with bbram reset flags set. */
+#define CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+
 /* SOC */
 #define CONFIG_CHIPSET_SKYLAKE
 #define CONFIG_CHIPSET_HAS_PLATFORM_PMIC_RESET

--- a/board/fizz/board.h
+++ b/board/fizz/board.h
@@ -68,10 +68,6 @@
 
 /* Enable After G3 State. */
 #define CONFIG_AFTER_G3_STATE
-/* RO for FIZZ only supports AP_OFF as OFF flag. */
-#define CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG
-/* RO for FIZZ is bugged when jumping from RW with bbram reset flags set. */
-#define CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
 
 /* SOC */
 #define CONFIG_CHIPSET_SKYLAKE

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -443,7 +443,7 @@ static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook)
 	/*
 	 * Sync OFF system reset flags to match the device state, otherwise
 	 * these flags can get carried via jump data to power button initial
-	 * state setup and cause issues after the jump...
+	 * state setup and cause issues after any potential future jump...
 	 */
 	 if (is_device_on) {
 		 /* The device is on, prevent abnormal state. */
@@ -514,7 +514,7 @@ static int command_after_g3_state(int argc, char **argv)
 }
 DECLARE_CONSOLE_COMMAND(afterg3state, command_after_g3_state,
 			"[off|on|previous]",
-			"Set or get After G3 State value");
+			"Get or set After G3 State value");
 
 #else /* !CONFIG_AFTER_G3_STATE */
 

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -245,7 +245,7 @@ static const char *ag3s_title = "After G3 State";
 static enum ec_after_g3_state ag3s_state = AG3S_DEFAULT_STATE;
 
 /*
- * Order should match enum ec_after_g3_state, starting from value 1.
+ * Order should match enum ec_after_g3_state, starting from value 0.
  * Special values are excluded.
  */
 static const char *ag3s_name_table[] = { "off", "on", "previous" };
@@ -254,7 +254,7 @@ static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
 {
 	return ((state >= EC_AFTER_G3_STATE_OFF &&
 	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
-			ag3s_name_table[state - 1] : NULL);
+			ag3s_name_table[state] : NULL);
 }
 
 static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
@@ -262,7 +262,7 @@ static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
 	int i, len;
 	for (i = 0, len = ARRAY_SIZE(ag3s_name_table); i < len; ++i) {
 		if (!strcasecmp(name, ag3s_name_table[i]))
-			return i + 1;
+			return i;
 	}
 	return EC_AFTER_G3_STATE_UNKNOWN;
 }

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -407,7 +407,7 @@ static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook)
 		ag3s_update_off_reset_flags(rfo_flags);
 		cflush();
 
-		/* Proper flag sync skipped due to the pending image jump. */
+		/* Proper flag sync skipped due to the pre-jump flag fix. */
 		return;
 	case AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE:
 	case AG3S_SYNC_HOOK_CHIPSET_STARTUP:

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -115,123 +115,7 @@ static void power_button_init(void)
 }
 DECLARE_HOOK(HOOK_INIT, power_button_init, HOOK_PRIO_INIT_POWER_BUTTON);
 
-/*
- *====================
- * After G3 State
- *====================
- *
- * Required headers:
- *   #include "chipset.h"
- *   #include "common.h"
- *   #include "console.h"
- *   #include "hooks.h"
- *   #include "host_command.h"
- *   #include "system.h"
- *   #include "util.h"
- *
- * Only useful for boards with dedicated 3V coin battery to sustain bbram, and
- * only for EC images compiled with CONFIG_POWER_BUTTON_INIT_IDLE, as this
- * ensures that OFF bbram reset flags are retained.
- *
- * Available "board/NAME/board.h" config macros:
- *
- *==========
- *== Enable After G3 State, otherwise legacy OFF flag handling will be used.
- *==========
- * #define CONFIG_AFTER_G3_STATE
- *
- *==========
- *== Use RESET_FLAG_AP_OFF/EC_RESET_FLAG_AP_OFF as OFF flag, instead of using
- *== EC_RESET_FLAG_AP_IDLE as OFF flag.
- *==
- *== FIZZ, and older boards, do not support AP_IDLE, and should use AP_OFF as
- *== OFF flag. PUFF, and newer boards, have been migrated to AP_IDLE as OFF
- *== flag, and should use AP_IDLE.
- *==========
- * #define CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG
- *
- *==========
- *== Enables fix for bbram bug in older EC code, where presence of *any* bbram
- *== reset flags after a jump will discard jump data, and not mark image state
- *== as jumped to.
- *==
- *== Bug is caused by the fact that when EC image is executed after a jump, it
- *== first restores system reset flags from bbram reset flags via pathway:
- *==   main()->gpio_pre_init()->system_is_reboot_warm()->
- *==     system_check_reset_cause()
- *== Then it overwrites system reset flags with jump data reset flags via
- *== pathway:
- *==   main()->system_common_pre_init()
- *==
- *== In bugged firmware system_common_pre_init() will only restore jump data if
- *== condition "system_reset == 0" (system reset flags == 0) evaluates to TRUE.
- *==
- *== This creates a risk of causing auto power on if device is off, or risk of
- *== inducing abnormal state (initializing power button as off) if device is
- *== running.
- *==
- *== Upstream fixed this is newer EC code by dropping the problematic condition:
- *==   https://github.com/MrChromebox/chrome-ec/commit/e833bdec81b9
- *== However, this is mainly suitable for fixing RW (jump RO->RW), as fixing RO
- *== would require overwriting factory RO, which poses a risk of bricking
- *== device, with no easy way to recover.
- *==
- *== Fixing RO (jump RW->RO), without actually changing RO, has two pathways:
- *==   1) Non-OFF bbram reset flags are NOT set when jumping. Fix will unset
- *==      any set OFF bbram reset flags. This has the following potential side
- *==      effects:
- *==        - If EC_AFTER_G3_STATE_OFF is set, while device is off/running, then
- *==          losing power before returning to RW will auto power on device when
- *==          power is restored.
- *==        - If EC_AFTER_G3_STATE_OFF/EC_AFTER_G3_STATE_PREVIOUS is set, while
- *==          device is off, then losing power power before returning to RW will
- *==          auto power on device when power is restored.
- *==   2) Non-OFF bbram reset flags are set when jumping. This means that jump
- *==      will be bugged anyway, since we do not want to touch non-OFF bbram
- *==      reset flags. Fix will adjust OFF bbram reset flags in a way to ensure
- *==      no abnormal state after jump. This has the following potential side
- *==      effects:
- *==        - If EC_AFTER_G3_STATE_OFF is set, while device is running, then
- *==          losing power before returning to RW will auto power on device when
- *==          power is restored.
- *==        - If EC_AFTER_G3_STATE_ON is set, while device is off, then losing
- *==          power before returning to RW will keep device off when power is
- *==          restored.
- *==
- *== Useless for PUFF, and newer boards, as these should not be affected.
- *==========
- * #define CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
- *
- *==========
- *== DEDEDE, and newer boards, do not pass OFF system reset flags via jump data
- *== when jumping, even if set prior to jumping. If RO is unmodified, then
- *== jumping to RO (RW->RO), while device is off, will always cause auto power
- *== on. Jump to RW (RO->RW) is not affected, since RW can restore OFF system
- *== reset flags based on checking existing OFF bbram reset flags.
- *==
- *== Mitigation requires changing code for RW (only if RO is unmodified):
- *== common/system.c: int system_run_image_copy_with_flags(enum ec_image copy,
- *==                                                  uint32_t add_reset_flags)
- *==     [...]
- *==     system_set_reset_flags(add_reset_flags);
- *==     [...]
- *==   ->
- *==     [...]
- *== #ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_PRESERVE_JDATA_AP_IDLE_IF_OFF
- *==      * Preserve system reset flag AP_IDLE (if set) before jumping, while
- *==      * device is off, to pass it via jump data, preventing auto powering on
- *==      * after jumping.
- *==     if (chipset_in_state(CHIPSET_STATE_ANY_OFF))
- *==         add_reset_flags |= system_get_reset_flags() &
- *==                            EC_RESET_FLAG_AP_IDLE;
- *== #endif
- *==     system_set_reset_flags(add_reset_flags);
- *==     [...]
- *==
- *== And defining the intent to use the fix:
- *==========
- * #define CONFIG_AFTER_G3_STATE_SYSJUMP_PRESERVE_JDATA_AP_IDLE_IF_OFF
- */
+/* After G3 State - enabling will disable legacy OFF reset flag handling. */
 #ifdef CONFIG_AFTER_G3_STATE
 
 static const char *ag3s_title = "After G3 State";
@@ -240,21 +124,18 @@ static const char *ag3s_title = "After G3 State";
  * Value set here (enum ec_after_g3_state) represents the default after G3
  * behavior, which can be later changed via command/coreboot.
  */
-#define AG3S_DEFAULT_STATE  (EC_AFTER_G3_STATE_PREVIOUS)
+#define AG3S_DEFAULT_STATE (EC_AFTER_G3_STATE_PREVIOUS)
 
 static enum ec_after_g3_state ag3s_state = AG3S_DEFAULT_STATE;
 
-/*
- * Order should match enum ec_after_g3_state, starting from value 0.
- * Special values are excluded.
- */
+/* Order should match enum ec_after_g3_state, starting from value 0. */
 static const char *ag3s_name_table[] = { "off", "on", "previous" };
 
 static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
 {
 	return ((state >= EC_AFTER_G3_STATE_OFF &&
-	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
-			ag3s_name_table[state] : NULL);
+		 state <= EC_AFTER_G3_STATE_PREVIOUS) ?
+		ag3s_name_table[state] : NULL);
 }
 
 static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
@@ -272,10 +153,9 @@ static inline enum ec_after_g3_state ag3s_get_state(void)
 	return ag3s_state;
 }
 
-static inline void ag3s_sync_reset_flags(void);
+static inline void ag3s_sync(void);
 
-static int ag3s_set_state_ex(enum ec_after_g3_state state, int preserve_state,
-		int sync_reset_flags)
+static int ag3s_set_state(enum ec_after_g3_state state)
 {
 	const char *state_name = ag3s_get_state_name(state);
 	if (!state_name)
@@ -285,37 +165,28 @@ static int ag3s_set_state_ex(enum ec_after_g3_state state, int preserve_state,
 
 	ag3s_state = state;
 
-	if (preserve_state) {
-		/* TODO: Coreboot-independent preservation. */
-	}
-
-	if (sync_reset_flags)
-		ag3s_sync_reset_flags();
+	ag3s_sync();
 
 	return 1;
-}
-
-static inline int ag3s_set_state(enum ec_after_g3_state state)
-{
-	return ag3s_set_state_ex(state, 1, 1);
 }
 
 /* Clearing operation always take precedence over saving for the same target. */
 enum ag3s_reset_flags_op_flags {
 	AG3S_RFO_SET_BBRM = (1 << 0),
 	AG3S_RFO_SET_SYS  = (1 << 1),
-	AG3S_RFO_SET      = (AG3S_RFO_SET_BBRM | AG3S_RFO_SET_SYS),
 	AG3S_RFO_CLR_BBRM = (1 << 2),
-	AG3S_RFO_CLR_SYS  = (1 << 3),
-	AG3S_RFO_CLR      = (AG3S_RFO_CLR_BBRM | AG3S_RFO_CLR_SYS)
+	AG3S_RFO_CLR_SYS  = (1 << 3)
 };
 
-static void ag3s_update_reset_flags(const char *name, uint32_t flags,
-		int rfo_flags)
+/* Reset flags used to keep the device off when power is restored. */
+#define AG3S_RESET_FLAG_OFF      (RESET_FLAG_AP_OFF)
+#define AG3S_RESET_FLAG_OFF_NAME "AP_OFF"
+
+static void ag3s_update_off_reset_flags(int rfo_flags)
 {
-	static const char *str_op_set = "+";
-	static const char *str_op_clr = "-";
-	static const char *str_op_eq  = "=";
+	static const char *op_set = "+";
+	static const char *op_clr = "-";
+	static const char *op_eq  = "=";
 
 	const char *op_bbram, *op_sys;
 
@@ -323,58 +194,29 @@ static void ag3s_update_reset_flags(const char *name, uint32_t flags,
 		return;
 
 	if (rfo_flags & AG3S_RFO_CLR_BBRM) {
-		chip_save_reset_flags(chip_read_reset_flags() & ~flags);
-		op_bbram = str_op_clr;
+		chip_save_reset_flags(chip_read_reset_flags() &
+				      ~AG3S_RESET_FLAG_OFF);
+		op_bbram = op_clr;
 	} else if (rfo_flags & AG3S_RFO_SET_BBRM) {
-		chip_save_reset_flags(chip_read_reset_flags() | flags);
-		op_bbram = str_op_set;
+		chip_save_reset_flags(chip_read_reset_flags() |
+				      AG3S_RESET_FLAG_OFF);
+		op_bbram = op_set;
 	} else {
-		op_bbram = str_op_eq;
+		op_bbram = op_eq;
 	}
 
 	if (rfo_flags & AG3S_RFO_CLR_SYS) {
-		system_clear_reset_flags(flags);
-		op_sys = str_op_clr;
+		system_clear_reset_flags(AG3S_RESET_FLAG_OFF);
+		op_sys = op_clr;
 	} else if (rfo_flags & AG3S_RFO_SET_SYS) {
-		system_set_reset_flags(flags);
-		op_sys = str_op_set;
+		system_set_reset_flags(AG3S_RESET_FLAG_OFF);
+		op_sys = op_set;
 	} else {
-		op_sys = str_op_eq;
+		op_sys = op_eq;
 	}
 
-	CPRINTS("%s: %s flag updated (%sbbram, %ssys)", ag3s_title, name,
-			op_bbram, op_sys);
-}
-
-/* Use AP_OFF as OFF flag if requested. */
-#if defined(CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG)
-  /*
-   * In newer EC code RESET_FLAG_AP_OFF could have been migrated to
-   * EC_RESET_FLAG_AP_OFF, AG3S_RESET_FLAG_AP_OFF macro is a shortcut to point
-   * to the existing AP_OFF flag.
-   */
-# if defined(RESET_FLAG_AP_OFF)
-#  define AG3S_RESET_FLAG_AP_OFF  (RESET_FLAG_AP_OFF)
-# elif defined(EC_RESET_FLAG_AP_OFF)
-#  define AG3S_RESET_FLAG_AP_OFF  (EC_RESET_FLAG_AP_OFF)
-# else
-#  error "CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG is defined, but" \
-         " required RESET_FLAG_AP_OFF or EC_RESET_FLAG_AP_OFF is not available"
-# endif
-# define AG3S_RESET_FLAG_OFF       (AG3S_RESET_FLAG_AP_OFF)
-# define AG3S_RESET_FLAG_OFF_NAME  "AP_OFF"
-#else /* Fallback to AP_IDLE as OFF flag if AP_OFF is not requested. */
-# if !defined(EC_RESET_FLAG_AP_IDLE)
-#  error "Required EC_RESET_FLAG_AP_IDLE is not available"
-# endif
-# define AG3S_RESET_FLAG_OFF       (EC_RESET_FLAG_AP_IDLE)
-# define AG3S_RESET_FLAG_OFF_NAME  "AP_IDLE"
-#endif
-
-static inline void ag3s_update_off_reset_flags(int rfo_flags)
-{
-	ag3s_update_reset_flags(AG3S_RESET_FLAG_OFF_NAME, AG3S_RESET_FLAG_OFF,
-			rfo_flags);
+	CPRINTS("%s: " AG3S_RESET_FLAG_OFF_NAME " flag updated"
+	        " (%sbbram, %ssys)", ag3s_title, op_bbram, op_sys);
 }
 
 static inline int ag3s_are_any_off_bbram_reset_flags_set(void)
@@ -382,47 +224,32 @@ static inline int ag3s_are_any_off_bbram_reset_flags_set(void)
 	return !!(chip_read_reset_flags() & AG3S_RESET_FLAG_OFF);
 }
 
-#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
 static inline int ag3s_are_any_non_off_bbram_reset_flags_set(void)
 {
 	return !!(chip_read_reset_flags() & ~AG3S_RESET_FLAG_OFF);
 }
-#endif
 
-/*
- * Hard/soft EC reboot is not hookable, but it will always unset OFF bbram reset
- * flags via system_reset(), unless specifically instructed not to do so. There
- * should be no risk of passing unwanted OFF bbram reset flags to RO, which
- * could cause issues.
- */
 enum ag3s_sync_hook {
+	/* Reserved for non-hook sync request. */
+	AG3S_SYNC_HOOK_NONE = -1,
 	/*
 	 * HOOK_INIT with HOOK_PRIO_DEFAULT-1.
 	 *
 	 * Called before power button initial state is configured (on HOOK_INIT
-	 * with HOOK_PRIO_DEFAULT). Changing OFF system reset flags here can
-	 * influence power button initial state, either allowing device to auto
-	 * power on, or prevent auto power on.
+	 * with HOOK_PRIO_DEFAULT). Changing OFF system reset flags at this
+	 * point can either make the device remain off or auto power it on.
 	 */
-	AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE = 1,
+	AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE,
 	/*
 	 * HOOK_INIT with HOOK_PRIO_DEFAULT+1.
 	 *
 	 * Called after power button initial state is configured.
-	 *
-	 * It should be safe now to properly sync reset flags, to match
-	 * currently set after G3 behavior.
 	 */
 	AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE,
 	/*
 	 * HOOK_CHIPSET_STARTUP with HOOK_PRIO_DEFAULT.
 	 *
 	 * Called on chipset startup.
-	 *
-	 * Checking for CHIPSET_STATE_ANY_OFF will evaluate to FALSE.
-	 *
-	 * OFF system reset flags should be unset here, while OFF bbram reset
-	 * flags can be set based on after G3 behavior.
 	 */
 	AG3S_SYNC_HOOK_CHIPSET_STARTUP,
 	/*
@@ -433,42 +260,24 @@ enum ag3s_sync_hook {
 	 *
 	 * Chipset is still NOT OFF at this point, trying to check for
 	 * CHIPSET_STATE_ANY_OFF will evaluate to FALSE.
-	 *
-	 * OFF system reset flags should be set here, while bbram OFF reset
-	 * flags can be set based on after G3 behavior.
 	 */
 	AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN,
-#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
 	/*
 	 * HOOK_SYSJUMP with HOOK_PRIO_LAST.
 	 *
 	 * Called before making a jump to another image, as late as possible.
 	 *
-	 * Hard/soft EC reboot, which automatically reverts to RO, does not emit
-	 * this hook.
-	 *
-	 * System reset flags are saved to jump data before HOOK_SYSJUMP is
-	 * called. Any attempt to change these flags within a hook will not make
-	 * any difference:
-	 *   static void jump_to_image(uintptr_t init_addr):
-	 *       [...]
-	 *       // reset_flags in this context point to global variable storing
-	 *       // active system reset flags
-	 *       jdata->reset_flags = reset_flags;
-	 *       [...]
-	 *       hook_notify(HOOK_SYSJUMP);
-	 *       [...]
+	 * Attempting to modify system reset flags from this hook has no effect,
+	 * as these flags are already saved to jump data prior to calling
+	 * HOOK_SYSJUMP.
 	 *
 	 * This hook requires explicit console flushing to avoid truncated
 	 * output, since it is called right before jumping.
+	 *
+	 * Only used to fix FIZZ EC bug. See AG3S_SYNC_HOOK_SYSJUMP case in
+	 * ag3s_sync_on_hook() for more info.
 	 */
-	AG3S_SYNC_HOOK_SYSJUMP,
-#endif /* CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX */
-
-	/* Special Values */
-
-	/* Reserved for non-hook related call. */
-	AG3S_SYNC_HOOK_NONE = 0
+	AG3S_SYNC_HOOK_SYSJUMP
 };
 
 static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook);
@@ -479,115 +288,116 @@ static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook);
 		ag3s_sync_on_hook(d_sync_hook_enum); \
 	} \
 	DECLARE_HOOK(d_hook, ag3s_sync_on_hook_##d_sync_hook_enum, \
-			d_hook_priority)
+		     d_hook_priority)
 
-/* Syncing on all non-special values in enum ag3s_sync_hook. */
+/* Sync on all valid hooks in enum ag3s_sync_hook. */
 AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE, HOOK_INIT,
-		HOOK_PRIO_DEFAULT-1);
+		  HOOK_PRIO_DEFAULT-1);
 AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE, HOOK_INIT,
-		HOOK_PRIO_DEFAULT+1);
+		  HOOK_PRIO_DEFAULT+1);
 AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_CHIPSET_STARTUP, HOOK_CHIPSET_STARTUP,
-		HOOK_PRIO_DEFAULT);
+		  HOOK_PRIO_DEFAULT);
 AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN, HOOK_CHIPSET_SHUTDOWN,
-		HOOK_PRIO_DEFAULT-1);
-#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+		  HOOK_PRIO_DEFAULT-1);
 AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_SYSJUMP, HOOK_SYSJUMP, HOOK_PRIO_LAST);
-#endif
-
-/*
- * Checks for errors on chipset shutdown, allowing to determine if shutdown is
- * considered graceful.
- *
- * Returns 0 if shutdown is graceful, otherwise shutdown is not graceful.
- */
-static inline int ag3s_on_chipset_shutdown_check_err(void)
-{
-	/* Shutting down due to power failure. */
-	if (chipset_get_shutdown_reason() == CHIPSET_SHUTDOWN_POWERFAIL)
-		return 1;
-
-	return 0;
-}
 
 static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook)
 {
+	int rfo_flags = 0;
+	int is_device_on;
 	enum ec_after_g3_state state;
 	const char *state_name;
+
 	/*
-	 * CHIPSET_STATE_ANY_OFF will not evaluate to TRUE during chipset
-	 * shutdown, so instead we always assume system is going off.
+	 * CHIPSET_STATE_ANY_OFF will not evaluate to TRUE on chipset shutdown,
+	 * so instead we always assume the device is going off.
 	 */
-	int any_off = (sync_hook == AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN ||
-			chipset_in_state(CHIPSET_STATE_ANY_OFF));
-	int rfo_flags = 0;
+	is_device_on = (sync_hook != AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN &&
+			!chipset_in_state(CHIPSET_STATE_ANY_OFF));
 
 	state = ag3s_get_state();
 	state_name = ag3s_get_state_name(state);
 	if (!state_name) {
-		state_name = "x";
 		/* Fallback to default state if state is invalid. */
 		state = AG3S_DEFAULT_STATE;
+		state_name = "x";
 	}
 
 	CPRINTS("%s: Sync on hook %d (%s)", ag3s_title, sync_hook, state_name);
 
 	/*
 	 * Some hooks may require special handling of reset flags. These hooks
-	 * take precedence over proper reset flag syncing.
+	 * take precedence over proper flag sync.
 	 */
 	switch(sync_hook) {
 	case AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE:
-		if (!any_off) {
+		if (is_device_on) {
 			/*
-			 * OFF system reset flags are always unset if device is
-			 * running, otherwise power button initial state setup
-			 * may trigger buggy behavior.
+			 * Unset OFF system reset flags if device is on,
+			 * otherwise power button initial state setup may cause
+			 * abnormal state.
 			 */
 			rfo_flags = AG3S_RFO_CLR_SYS;
 		} else if (ag3s_are_any_off_bbram_reset_flags_set()) {
 			/*
-			 * Presence of OFF bbram reset flags, while device is
-			 * off, indicates that device should remain off. OFF
-			 * system reset flags are explicitly set, to ensure
-			 * power button initial state configuration will inhibit
-			 * auto power on.
+			 * Presence of OFF bbram reset flags, while the device
+			 * is off, indicates that it should remain off. Set OFF
+			 * system reset flags to ensure power button initial
+			 * state setup will prevent auto power on.
 			 */
 			rfo_flags = AG3S_RFO_SET_SYS;
 		}
 
-		/* Proper flag syncing will be done after power button init. */
-		goto update_reset_flags;
+		/* Proper flag sync will be done after power button init. */
+		goto update_off_reset_flags;
 	case AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN:
-		/*
-		 * "Previous State" behavior should NOT save OFF bbram reset
-		 * flags if there are errors on shutdown. This ensures that
-		 * device will only stay off, when power is reapplied, if
-		 * shutdown was graceful, otherwise it will auto power on.
-		 */
 		if (state == EC_AFTER_G3_STATE_PREVIOUS &&
-		    ag3s_on_chipset_shutdown_check_err())
+		    chipset_get_shutdown_reason() ==
+		    CHIPSET_SHUTDOWN_POWERFAIL) {
+			/*
+			 * Skip saving OFF bbram reset flags for "Previous
+			 * State" behavior if shutting down due to power
+			 * failure. This ensures that the device will remain off
+			 * when power is restored only if shutdown was graceful,
+			 * otherwise it will auto power on.
+			 */
 			return;
+		}
 		break;
-#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
 	case AG3S_SYNC_HOOK_SYSJUMP:
 		/*
-		 * Bugged EC will discard jump data if *any* bbram reset flags
-		 * are present after a jump.
-		 *
-		 * We always unset OFF bbram reset flags, unless there are other
-		 * reset flags in bbram, then jump will be bugged anyway, so we
-		 * set OFF bbram reset flags based on current device state.
-		 *
-		 * Regardless of the pathway we have taken, device may not
-		 * respect currently set after G3 behavior when power is
-		 * lost/restored, but at least we can avoid issues with device
-		 * abnormal states if running, or auto powering on if off.
+		 * In the bugged image, the "system_reset == 0" condition
+		 * (system reset flags == 0) in system_common_pre_init() will
+		 * cause jump data to be discarded. This makes system reset
+		 * flags reflect what was passed in bbram reset flags at the
+		 * time of the jump instead of system reset flags passed via
+		 * jump data. These flags can then get carried to power button
+		 * initial state setup and cause issues.
 		 */
-		if (!ag3s_are_any_non_off_bbram_reset_flags_set()) {
-			rfo_flags = AG3S_RFO_CLR_BBRM;
+		if (ag3s_are_any_non_off_bbram_reset_flags_set()) {
+			/*
+			 * If non-OFF bbram reset flags are present, then the
+			 * jump will be bugged and system reset flags will
+			 * reflect bbram reset flags at the time of the jump.
+			 * Adjust OFF bbram reset flags to match the device
+			 * state to ensure no issues in power button initial
+			 * state setup after the jump...
+			 */
+			if (is_device_on) {
+				/* The device is on, prevent abnormal state. */
+				rfo_flags = AG3S_RFO_CLR_BBRM;
+			} else {
+				/* The device is off, prevent auto power on. */
+				rfo_flags = AG3S_RFO_SET_BBRM;
+			}
 		} else {
-			rfo_flags = (any_off ?
-					AG3S_RFO_SET_BBRM : AG3S_RFO_CLR_BBRM);
+			/*
+			 * If non-OFF bbram reset flags are not set, then we
+			 * just unset OFF bbram reset flags to make sure there
+			 * are no bbram reset flags at all. This allows to
+			 * avoid triggering the bug.
+			 */
+			rfo_flags = AG3S_RFO_CLR_BBRM;
 		}
 
 		/*
@@ -597,140 +407,115 @@ static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook)
 		ag3s_update_off_reset_flags(rfo_flags);
 		cflush();
 
-		/* Proper flag syncing skipped due to pending image jump. */
+		/* Proper flag sync skipped due to the pending image jump. */
 		return;
-#endif /* CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX */
 	case AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE:
 	case AG3S_SYNC_HOOK_CHIPSET_STARTUP:
 	case AG3S_SYNC_HOOK_NONE:
 	default:
-		/* No special action needed, just do a proper flag syncing. */
+		/* No special action needed, just do proper flag sync. */
 		break;
 	}
 
-	/* Syncing OFF reset flags based on currently set after G3 behavior. */
+	/* Sync OFF bbram reset flags to match the current after G3 behavior. */
 	switch (state) {
 	case EC_AFTER_G3_STATE_OFF:
-		if (!any_off) {
-			/*
-			 * If device is running, then OFF system reset flags are
-			 * always unset, otherwise these flags can get carried
-			 * via jump data and trigger buggy behavior.
-			 */
-			rfo_flags = AG3S_RFO_CLR_SYS;
-
-			/*
-			 * OFF bbram reset flags are always set. After power
-			 * failure device will stay off when power is reapplied.
-			 */
-			rfo_flags |= AG3S_RFO_SET_BBRM;
-		} else {
-			/*
-			 * If device is off, then OFF reset flags are always
-			 * set, after power failure device will stay off when
-			 * power is reapplied.
-			 */
-			rfo_flags = AG3S_RFO_SET;
-		}
+		/* Keep the device off when power is restored. */
+		rfo_flags = AG3S_RFO_SET_BBRM;
 		break;
 	case EC_AFTER_G3_STATE_ON:
-		if (!any_off) {
-			/*
-			 * If device is running, then OFF reset flags are unset.
-			 * After power failure device will auto power on when
-			 * power is reapplied.
-			 */
-			rfo_flags = AG3S_RFO_CLR;
-		} else {
-			/*
-			 * If device is off, then OFF bbram reset flags are
-			 * unset. After power failure device will auto power on
-			 * when power is reapplied.
-			 */
-			rfo_flags = AG3S_RFO_CLR_BBRM;
-
-			/*
-			 * OFF system reset flags are set to prevent device from
-			 * auto powering on after jumping (via jump data). These
-			 * flags are lost on power loss, therefore should not
-			 * interfere with auto powering on.
-			 */
-			rfo_flags |= AG3S_RFO_SET_SYS;
-		}
+		/* Auto power on the device when power is restored. */
+		rfo_flags = AG3S_RFO_CLR_BBRM;
 		break;
 	case EC_AFTER_G3_STATE_PREVIOUS:
 	default: /* Fallback to "Previous State" if state is invalid. */
-		/*
-		 * If device is off, then OFF reset flags are set, otherwise
-		 * these flags are unset. After power failure device will stay
-		 * off when power is reapplied, but only if it was off before
-		 * power was lost, otherwise it will auto power on.
-		 */
-		rfo_flags = (any_off ? AG3S_RFO_SET : AG3S_RFO_CLR);
+		/* Match the device state when power is restored... */
+		if (is_device_on) {
+			/* The device is on, auto power it on. */
+			rfo_flags = AG3S_RFO_CLR_BBRM;
+		} else {
+			/* The device is off, keep the device off. */
+			rfo_flags = AG3S_RFO_SET_BBRM;
+		}
 		break;
 	}
 
-update_reset_flags:
+	/*
+	 * Sync OFF system reset flags to match the device state, otherwise
+	 * these flags can get carried via jump data to power button initial
+	 * state setup and cause issues after the jump...
+	 */
+	 if (is_device_on) {
+		 /* The device is on, prevent abnormal state. */
+		 rfo_flags |= AG3S_RFO_CLR_SYS;
+	 } else {
+		 /* The device is off, prevent auto power on. */
+		 rfo_flags |= AG3S_RFO_SET_SYS;
+	 }
+
+update_off_reset_flags:
 	ag3s_update_off_reset_flags(rfo_flags);
 }
 
-static inline void ag3s_sync_reset_flags(void)
+static inline void ag3s_sync(void)
 {
 	ag3s_sync_on_hook(AG3S_SYNC_HOOK_NONE);
 }
 
-static int host_command_after_g3_state(struct host_cmd_handler_args *args)
+static int host_command_after_g3_state_set(struct host_cmd_handler_args *args)
 {
-	const struct ec_params_after_g3_state *p = args->params;
-	struct ec_response_after_g3_state *r = args->response;
-	enum ec_after_g3_state set_state = p->set_state;
-	int rv = EC_RES_SUCCESS;
+	const struct ec_params_after_g3_state_set *p = args->params;
 
-	if (set_state != EC_AFTER_G3_STATE_GET && !ag3s_set_state(set_state))
-		rv = EC_RES_ERROR;
+	if (!ag3s_set_state(p->state))
+		return EC_RES_ERROR;
 
-	r->cur_state = (uint8_t)(rv == EC_RES_SUCCESS ?
-			ag3s_get_state() : EC_AFTER_G3_STATE_ERROR);
+	return EC_RES_SUCCESS;
+}
+DECLARE_HOST_COMMAND(EC_CMD_AFTER_G3_STATE_SET, host_command_after_g3_state_set,
+		     EC_VER_MASK(0));
+
+static int host_command_after_g3_state_get(struct host_cmd_handler_args *args)
+{
+	struct ec_response_after_g3_state_get *r = args->response;
+
+	r->state = (int8_t)ag3s_get_state();
 	args->response_size = sizeof(*r);
 
-	return rv;
+	return EC_RES_SUCCESS;
 }
-DECLARE_HOST_COMMAND(EC_CMD_AFTER_G3_STATE, host_command_after_g3_state,
-		EC_VER_MASK(0));
+DECLARE_HOST_COMMAND(EC_CMD_AFTER_G3_STATE_GET, host_command_after_g3_state_get,
+		     EC_VER_MASK(0));
 
 static int command_after_g3_state(int argc, char **argv)
 {
+	enum ec_after_g3_state state;
 	const char *state_name;
 
 	if (argc < 2) {
-		state_name = ag3s_get_state_name(ag3s_get_state());
-		if (!state_name)
-			return EC_ERROR_UNKNOWN;
+		state = ag3s_get_state();
 	} else if (argc == 2) {
-		enum ec_after_g3_state state = ag3s_find_state_by_name(argv[1]);
+		state = ag3s_find_state_by_name(argv[1]);
 		if (state == EC_AFTER_G3_STATE_UNKNOWN)
 			return EC_ERROR_PARAM1;
-		/* Normalize state name. */
-		state_name = ag3s_get_state_name(state);
-		if (!state_name || !ag3s_set_state(state))
+
+		if (!ag3s_set_state(state))
 			return EC_ERROR_UNKNOWN;
 	} else {
 		return EC_ERROR_PARAM_COUNT;
 	}
+
+	state_name = ag3s_get_state_name(state);
+	if (!state_name)
+		return EC_ERROR_UNKNOWN;
 
 	ccprintf("%s: %s\n", ag3s_title, state_name);
 
 	return EC_SUCCESS;
 }
 DECLARE_CONSOLE_COMMAND(afterg3state, command_after_g3_state,
-		"[off|on|previous]",
-		"Set and/or get After G3 State value");
+			"[off|on|previous]",
+			"Set or get After G3 State value");
 
-/*
- * Only use legacy code for handling OFF reset flags if CONFIG_AFTER_G3_STATE is
- * not defined. This way any upstream changes affecting legacy code could still
- * be merged, but will not be compiled, and will not affect After G3 State.
- */
 #else /* !CONFIG_AFTER_G3_STATE */
 
 #ifdef CONFIG_POWER_BUTTON_INIT_IDLE

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -178,7 +178,7 @@ enum ag3s_reset_flags_op_flags {
 	AG3S_RFO_CLR_SYS  = (1 << 3)
 };
 
-/* Reset flags used to keep the device off when power is restored. */
+/* Reset flags used to keep the device off. */
 #define AG3S_RESET_FLAG_OFF      (RESET_FLAG_AP_OFF)
 #define AG3S_RESET_FLAG_OFF_NAME "AP_OFF"
 

--- a/common/power_button.c
+++ b/common/power_button.c
@@ -115,6 +115,624 @@ static void power_button_init(void)
 }
 DECLARE_HOOK(HOOK_INIT, power_button_init, HOOK_PRIO_INIT_POWER_BUTTON);
 
+/*
+ *====================
+ * After G3 State
+ *====================
+ *
+ * Required headers:
+ *   #include "chipset.h"
+ *   #include "common.h"
+ *   #include "console.h"
+ *   #include "hooks.h"
+ *   #include "host_command.h"
+ *   #include "system.h"
+ *   #include "util.h"
+ *
+ * Only useful for boards with dedicated 3V coin battery to sustain bbram, and
+ * only for EC images compiled with CONFIG_POWER_BUTTON_INIT_IDLE, as this
+ * ensures that OFF bbram reset flags are retained.
+ *
+ * Available "board/NAME/board.h" config macros:
+ *
+ *==========
+ *== Enable After G3 State, otherwise legacy OFF flag handling will be used.
+ *==========
+ * #define CONFIG_AFTER_G3_STATE
+ *
+ *==========
+ *== Use RESET_FLAG_AP_OFF/EC_RESET_FLAG_AP_OFF as OFF flag, instead of using
+ *== EC_RESET_FLAG_AP_IDLE as OFF flag.
+ *==
+ *== FIZZ, and older boards, do not support AP_IDLE, and should use AP_OFF as
+ *== OFF flag. PUFF, and newer boards, have been migrated to AP_IDLE as OFF
+ *== flag, and should use AP_IDLE.
+ *==========
+ * #define CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG
+ *
+ *==========
+ *== Enables fix for bbram bug in older EC code, where presence of *any* bbram
+ *== reset flags after a jump will discard jump data, and not mark image state
+ *== as jumped to.
+ *==
+ *== Bug is caused by the fact that when EC image is executed after a jump, it
+ *== first restores system reset flags from bbram reset flags via pathway:
+ *==   main()->gpio_pre_init()->system_is_reboot_warm()->
+ *==     system_check_reset_cause()
+ *== Then it overwrites system reset flags with jump data reset flags via
+ *== pathway:
+ *==   main()->system_common_pre_init()
+ *==
+ *== In bugged firmware system_common_pre_init() will only restore jump data if
+ *== condition "system_reset == 0" (system reset flags == 0) evaluates to TRUE.
+ *==
+ *== This creates a risk of causing auto power on if device is off, or risk of
+ *== inducing abnormal state (initializing power button as off) if device is
+ *== running.
+ *==
+ *== Upstream fixed this is newer EC code by dropping the problematic condition:
+ *==   https://github.com/MrChromebox/chrome-ec/commit/e833bdec81b9
+ *== However, this is mainly suitable for fixing RW (jump RO->RW), as fixing RO
+ *== would require overwriting factory RO, which poses a risk of bricking
+ *== device, with no easy way to recover.
+ *==
+ *== Fixing RO (jump RW->RO), without actually changing RO, has two pathways:
+ *==   1) Non-OFF bbram reset flags are NOT set when jumping. Fix will unset
+ *==      any set OFF bbram reset flags. This has the following potential side
+ *==      effects:
+ *==        - If EC_AFTER_G3_STATE_OFF is set, while device is off/running, then
+ *==          losing power before returning to RW will auto power on device when
+ *==          power is restored.
+ *==        - If EC_AFTER_G3_STATE_OFF/EC_AFTER_G3_STATE_PREVIOUS is set, while
+ *==          device is off, then losing power power before returning to RW will
+ *==          auto power on device when power is restored.
+ *==   2) Non-OFF bbram reset flags are set when jumping. This means that jump
+ *==      will be bugged anyway, since we do not want to touch non-OFF bbram
+ *==      reset flags. Fix will adjust OFF bbram reset flags in a way to ensure
+ *==      no abnormal state after jump. This has the following potential side
+ *==      effects:
+ *==        - If EC_AFTER_G3_STATE_OFF is set, while device is running, then
+ *==          losing power before returning to RW will auto power on device when
+ *==          power is restored.
+ *==        - If EC_AFTER_G3_STATE_ON is set, while device is off, then losing
+ *==          power before returning to RW will keep device off when power is
+ *==          restored.
+ *==
+ *== Useless for PUFF, and newer boards, as these should not be affected.
+ *==========
+ * #define CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+ *
+ *==========
+ *== DEDEDE, and newer boards, do not pass OFF system reset flags via jump data
+ *== when jumping, even if set prior to jumping. If RO is unmodified, then
+ *== jumping to RO (RW->RO), while device is off, will always cause auto power
+ *== on. Jump to RW (RO->RW) is not affected, since RW can restore OFF system
+ *== reset flags based on checking existing OFF bbram reset flags.
+ *==
+ *== Mitigation requires changing code for RW (only if RO is unmodified):
+ *== common/system.c: int system_run_image_copy_with_flags(enum ec_image copy,
+ *==                                                  uint32_t add_reset_flags)
+ *==     [...]
+ *==     system_set_reset_flags(add_reset_flags);
+ *==     [...]
+ *==   ->
+ *==     [...]
+ *== #ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_PRESERVE_JDATA_AP_IDLE_IF_OFF
+ *==      * Preserve system reset flag AP_IDLE (if set) before jumping, while
+ *==      * device is off, to pass it via jump data, preventing auto powering on
+ *==      * after jumping.
+ *==     if (chipset_in_state(CHIPSET_STATE_ANY_OFF))
+ *==         add_reset_flags |= system_get_reset_flags() &
+ *==                            EC_RESET_FLAG_AP_IDLE;
+ *== #endif
+ *==     system_set_reset_flags(add_reset_flags);
+ *==     [...]
+ *==
+ *== And defining the intent to use the fix:
+ *==========
+ * #define CONFIG_AFTER_G3_STATE_SYSJUMP_PRESERVE_JDATA_AP_IDLE_IF_OFF
+ */
+#ifdef CONFIG_AFTER_G3_STATE
+
+static const char *ag3s_title = "After G3 State";
+
+/*
+ * Value set here (enum ec_after_g3_state) represents the default after G3
+ * behavior, which can be later changed via command/coreboot.
+ */
+#define AG3S_DEFAULT_STATE  (EC_AFTER_G3_STATE_PREVIOUS)
+
+static enum ec_after_g3_state ag3s_state = AG3S_DEFAULT_STATE;
+
+/*
+ * Order should match enum ec_after_g3_state, starting from value 1.
+ * Special values are excluded.
+ */
+static const char *ag3s_name_table[] = { "off", "on", "previous" };
+
+static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
+{
+	return ((state >= EC_AFTER_G3_STATE_OFF &&
+	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
+			ag3s_name_table[state - 1] : NULL);
+}
+
+static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
+{
+	int i, len;
+	for (i = 0, len = ARRAY_SIZE(ag3s_name_table); i < len; ++i) {
+		if (!strcasecmp(name, ag3s_name_table[i]))
+			return i + 1;
+	}
+	return EC_AFTER_G3_STATE_UNKNOWN;
+}
+
+static inline enum ec_after_g3_state ag3s_get_state(void)
+{
+	return ag3s_state;
+}
+
+static inline void ag3s_sync_reset_flags(void);
+
+static int ag3s_set_state_ex(enum ec_after_g3_state state, int preserve_state,
+		int sync_reset_flags)
+{
+	const char *state_name = ag3s_get_state_name(state);
+	if (!state_name)
+		return 0;
+
+	CPRINTS("%s: Updating to '%s'", ag3s_title, state_name);
+
+	ag3s_state = state;
+
+	if (preserve_state) {
+		/* TODO: Coreboot-independent preservation. */
+	}
+
+	if (sync_reset_flags)
+		ag3s_sync_reset_flags();
+
+	return 1;
+}
+
+static inline int ag3s_set_state(enum ec_after_g3_state state)
+{
+	return ag3s_set_state_ex(state, 1, 1);
+}
+
+/* Clearing operation always take precedence over saving for the same target. */
+enum ag3s_reset_flags_op_flags {
+	AG3S_RFO_SET_BBRM = (1 << 0),
+	AG3S_RFO_SET_SYS  = (1 << 1),
+	AG3S_RFO_SET      = (AG3S_RFO_SET_BBRM | AG3S_RFO_SET_SYS),
+	AG3S_RFO_CLR_BBRM = (1 << 2),
+	AG3S_RFO_CLR_SYS  = (1 << 3),
+	AG3S_RFO_CLR      = (AG3S_RFO_CLR_BBRM | AG3S_RFO_CLR_SYS)
+};
+
+static void ag3s_update_reset_flags(const char *name, uint32_t flags,
+		int rfo_flags)
+{
+	static const char *str_op_set = "+";
+	static const char *str_op_clr = "-";
+	static const char *str_op_eq  = "=";
+
+	const char *op_bbram, *op_sys;
+
+	if (!rfo_flags)
+		return;
+
+	if (rfo_flags & AG3S_RFO_CLR_BBRM) {
+		chip_save_reset_flags(chip_read_reset_flags() & ~flags);
+		op_bbram = str_op_clr;
+	} else if (rfo_flags & AG3S_RFO_SET_BBRM) {
+		chip_save_reset_flags(chip_read_reset_flags() | flags);
+		op_bbram = str_op_set;
+	} else {
+		op_bbram = str_op_eq;
+	}
+
+	if (rfo_flags & AG3S_RFO_CLR_SYS) {
+		system_clear_reset_flags(flags);
+		op_sys = str_op_clr;
+	} else if (rfo_flags & AG3S_RFO_SET_SYS) {
+		system_set_reset_flags(flags);
+		op_sys = str_op_set;
+	} else {
+		op_sys = str_op_eq;
+	}
+
+	CPRINTS("%s: %s flag updated (%sbbram, %ssys)", ag3s_title, name,
+			op_bbram, op_sys);
+}
+
+/* Use AP_OFF as OFF flag if requested. */
+#if defined(CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG)
+  /*
+   * In newer EC code RESET_FLAG_AP_OFF could have been migrated to
+   * EC_RESET_FLAG_AP_OFF, AG3S_RESET_FLAG_AP_OFF macro is a shortcut to point
+   * to the existing AP_OFF flag.
+   */
+# if defined(RESET_FLAG_AP_OFF)
+#  define AG3S_RESET_FLAG_AP_OFF  (RESET_FLAG_AP_OFF)
+# elif defined(EC_RESET_FLAG_AP_OFF)
+#  define AG3S_RESET_FLAG_AP_OFF  (EC_RESET_FLAG_AP_OFF)
+# else
+#  error "CONFIG_AFTER_G3_STATE_USE_AP_OFF_AS_OFF_FLAG is defined, but" \
+         " required RESET_FLAG_AP_OFF or EC_RESET_FLAG_AP_OFF is not available"
+# endif
+# define AG3S_RESET_FLAG_OFF       (AG3S_RESET_FLAG_AP_OFF)
+# define AG3S_RESET_FLAG_OFF_NAME  "AP_OFF"
+#else /* Fallback to AP_IDLE as OFF flag if AP_OFF is not requested. */
+# if !defined(EC_RESET_FLAG_AP_IDLE)
+#  error "Required EC_RESET_FLAG_AP_IDLE is not available"
+# endif
+# define AG3S_RESET_FLAG_OFF       (EC_RESET_FLAG_AP_IDLE)
+# define AG3S_RESET_FLAG_OFF_NAME  "AP_IDLE"
+#endif
+
+static inline void ag3s_update_off_reset_flags(int rfo_flags)
+{
+	ag3s_update_reset_flags(AG3S_RESET_FLAG_OFF_NAME, AG3S_RESET_FLAG_OFF,
+			rfo_flags);
+}
+
+static inline int ag3s_are_any_off_bbram_reset_flags_set(void)
+{
+	return !!(chip_read_reset_flags() & AG3S_RESET_FLAG_OFF);
+}
+
+#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+static inline int ag3s_are_any_non_off_bbram_reset_flags_set(void)
+{
+	return !!(chip_read_reset_flags() & ~AG3S_RESET_FLAG_OFF);
+}
+#endif
+
+/*
+ * Hard/soft EC reboot is not hookable, but it will always unset OFF bbram reset
+ * flags via system_reset(), unless specifically instructed not to do so. There
+ * should be no risk of passing unwanted OFF bbram reset flags to RO, which
+ * could cause issues.
+ */
+enum ag3s_sync_hook {
+	/*
+	 * HOOK_INIT with HOOK_PRIO_DEFAULT-1.
+	 *
+	 * Called before power button initial state is configured (on HOOK_INIT
+	 * with HOOK_PRIO_DEFAULT). Changing OFF system reset flags here can
+	 * influence power button initial state, either allowing device to auto
+	 * power on, or prevent auto power on.
+	 */
+	AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE = 1,
+	/*
+	 * HOOK_INIT with HOOK_PRIO_DEFAULT+1.
+	 *
+	 * Called after power button initial state is configured.
+	 *
+	 * It should be safe now to properly sync reset flags, to match
+	 * currently set after G3 behavior.
+	 */
+	AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE,
+	/*
+	 * HOOK_CHIPSET_STARTUP with HOOK_PRIO_DEFAULT.
+	 *
+	 * Called on chipset startup.
+	 *
+	 * Checking for CHIPSET_STATE_ANY_OFF will evaluate to FALSE.
+	 *
+	 * OFF system reset flags should be unset here, while OFF bbram reset
+	 * flags can be set based on after G3 behavior.
+	 */
+	AG3S_SYNC_HOOK_CHIPSET_STARTUP,
+	/*
+	 * HOOK_CHIPSET_SHUTDOWN with HOOK_PRIO_DEFAULT-1.
+	 *
+	 * Called when chipset is shutting down. Priority is slightly higher
+	 * than handle_pending_reboot() (HOOK_PRIO_DEFAULT).
+	 *
+	 * Chipset is still NOT OFF at this point, trying to check for
+	 * CHIPSET_STATE_ANY_OFF will evaluate to FALSE.
+	 *
+	 * OFF system reset flags should be set here, while bbram OFF reset
+	 * flags can be set based on after G3 behavior.
+	 */
+	AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN,
+#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+	/*
+	 * HOOK_SYSJUMP with HOOK_PRIO_LAST.
+	 *
+	 * Called before making a jump to another image, as late as possible.
+	 *
+	 * Hard/soft EC reboot, which automatically reverts to RO, does not emit
+	 * this hook.
+	 *
+	 * System reset flags are saved to jump data before HOOK_SYSJUMP is
+	 * called. Any attempt to change these flags within a hook will not make
+	 * any difference:
+	 *   static void jump_to_image(uintptr_t init_addr):
+	 *       [...]
+	 *       // reset_flags in this context point to global variable storing
+	 *       // active system reset flags
+	 *       jdata->reset_flags = reset_flags;
+	 *       [...]
+	 *       hook_notify(HOOK_SYSJUMP);
+	 *       [...]
+	 *
+	 * This hook requires explicit console flushing to avoid truncated
+	 * output, since it is called right before jumping.
+	 */
+	AG3S_SYNC_HOOK_SYSJUMP,
+#endif /* CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX */
+
+	/* Special Values */
+
+	/* Reserved for non-hook related call. */
+	AG3S_SYNC_HOOK_NONE = 0
+};
+
+static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook);
+
+#define AG3S_SYNC_ON_HOOK(d_sync_hook_enum, d_hook, d_hook_priority) \
+	static void ag3s_sync_on_hook_##d_sync_hook_enum(void) \
+	{ \
+		ag3s_sync_on_hook(d_sync_hook_enum); \
+	} \
+	DECLARE_HOOK(d_hook, ag3s_sync_on_hook_##d_sync_hook_enum, \
+			d_hook_priority)
+
+/* Syncing on all non-special values in enum ag3s_sync_hook. */
+AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE, HOOK_INIT,
+		HOOK_PRIO_DEFAULT-1);
+AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE, HOOK_INIT,
+		HOOK_PRIO_DEFAULT+1);
+AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_CHIPSET_STARTUP, HOOK_CHIPSET_STARTUP,
+		HOOK_PRIO_DEFAULT);
+AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN, HOOK_CHIPSET_SHUTDOWN,
+		HOOK_PRIO_DEFAULT-1);
+#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+AG3S_SYNC_ON_HOOK(AG3S_SYNC_HOOK_SYSJUMP, HOOK_SYSJUMP, HOOK_PRIO_LAST);
+#endif
+
+/*
+ * Checks for errors on chipset shutdown, allowing to determine if shutdown is
+ * considered graceful.
+ *
+ * Returns 0 if shutdown is graceful, otherwise shutdown is not graceful.
+ */
+static inline int ag3s_on_chipset_shutdown_check_err(void)
+{
+	/* Shutting down due to power failure. */
+	if (chipset_get_shutdown_reason() == CHIPSET_SHUTDOWN_POWERFAIL)
+		return 1;
+
+	return 0;
+}
+
+static void ag3s_sync_on_hook(enum ag3s_sync_hook sync_hook)
+{
+	enum ec_after_g3_state state;
+	const char *state_name;
+	/*
+	 * CHIPSET_STATE_ANY_OFF will not evaluate to TRUE during chipset
+	 * shutdown, so instead we always assume system is going off.
+	 */
+	int any_off = (sync_hook == AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN ||
+			chipset_in_state(CHIPSET_STATE_ANY_OFF));
+	int rfo_flags = 0;
+
+	state = ag3s_get_state();
+	state_name = ag3s_get_state_name(state);
+	if (!state_name) {
+		state_name = "x";
+		/* Fallback to default state if state is invalid. */
+		state = AG3S_DEFAULT_STATE;
+	}
+
+	CPRINTS("%s: Sync on hook %d (%s)", ag3s_title, sync_hook, state_name);
+
+	/*
+	 * Some hooks may require special handling of reset flags. These hooks
+	 * take precedence over proper reset flag syncing.
+	 */
+	switch(sync_hook) {
+	case AG3S_SYNC_HOOK_INIT_BEFORE_PB_ISTATE:
+		if (!any_off) {
+			/*
+			 * OFF system reset flags are always unset if device is
+			 * running, otherwise power button initial state setup
+			 * may trigger buggy behavior.
+			 */
+			rfo_flags = AG3S_RFO_CLR_SYS;
+		} else if (ag3s_are_any_off_bbram_reset_flags_set()) {
+			/*
+			 * Presence of OFF bbram reset flags, while device is
+			 * off, indicates that device should remain off. OFF
+			 * system reset flags are explicitly set, to ensure
+			 * power button initial state configuration will inhibit
+			 * auto power on.
+			 */
+			rfo_flags = AG3S_RFO_SET_SYS;
+		}
+
+		/* Proper flag syncing will be done after power button init. */
+		goto update_reset_flags;
+	case AG3S_SYNC_HOOK_CHIPSET_SHUTDOWN:
+		/*
+		 * "Previous State" behavior should NOT save OFF bbram reset
+		 * flags if there are errors on shutdown. This ensures that
+		 * device will only stay off, when power is reapplied, if
+		 * shutdown was graceful, otherwise it will auto power on.
+		 */
+		if (state == EC_AFTER_G3_STATE_PREVIOUS &&
+		    ag3s_on_chipset_shutdown_check_err())
+			return;
+		break;
+#ifdef CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX
+	case AG3S_SYNC_HOOK_SYSJUMP:
+		/*
+		 * Bugged EC will discard jump data if *any* bbram reset flags
+		 * are present after a jump.
+		 *
+		 * We always unset OFF bbram reset flags, unless there are other
+		 * reset flags in bbram, then jump will be bugged anyway, so we
+		 * set OFF bbram reset flags based on current device state.
+		 *
+		 * Regardless of the pathway we have taken, device may not
+		 * respect currently set after G3 behavior when power is
+		 * lost/restored, but at least we can avoid issues with device
+		 * abnormal states if running, or auto powering on if off.
+		 */
+		if (!ag3s_are_any_non_off_bbram_reset_flags_set()) {
+			rfo_flags = AG3S_RFO_CLR_BBRM;
+		} else {
+			rfo_flags = (any_off ?
+					AG3S_RFO_SET_BBRM : AG3S_RFO_CLR_BBRM);
+		}
+
+		/*
+		 * This hook requires explicit console flushing to avoid
+		 * truncated output, since it is called right before jumping.
+		 */
+		ag3s_update_off_reset_flags(rfo_flags);
+		cflush();
+
+		/* Proper flag syncing skipped due to pending image jump. */
+		return;
+#endif /* CONFIG_AFTER_G3_STATE_SYSJUMP_BBRAM_BUGFIX */
+	case AG3S_SYNC_HOOK_INIT_AFTER_PB_ISTATE:
+	case AG3S_SYNC_HOOK_CHIPSET_STARTUP:
+	case AG3S_SYNC_HOOK_NONE:
+	default:
+		/* No special action needed, just do a proper flag syncing. */
+		break;
+	}
+
+	/* Syncing OFF reset flags based on currently set after G3 behavior. */
+	switch (state) {
+	case EC_AFTER_G3_STATE_OFF:
+		if (!any_off) {
+			/*
+			 * If device is running, then OFF system reset flags are
+			 * always unset, otherwise these flags can get carried
+			 * via jump data and trigger buggy behavior.
+			 */
+			rfo_flags = AG3S_RFO_CLR_SYS;
+
+			/*
+			 * OFF bbram reset flags are always set. After power
+			 * failure device will stay off when power is reapplied.
+			 */
+			rfo_flags |= AG3S_RFO_SET_BBRM;
+		} else {
+			/*
+			 * If device is off, then OFF reset flags are always
+			 * set, after power failure device will stay off when
+			 * power is reapplied.
+			 */
+			rfo_flags = AG3S_RFO_SET;
+		}
+		break;
+	case EC_AFTER_G3_STATE_ON:
+		if (!any_off) {
+			/*
+			 * If device is running, then OFF reset flags are unset.
+			 * After power failure device will auto power on when
+			 * power is reapplied.
+			 */
+			rfo_flags = AG3S_RFO_CLR;
+		} else {
+			/*
+			 * If device is off, then OFF bbram reset flags are
+			 * unset. After power failure device will auto power on
+			 * when power is reapplied.
+			 */
+			rfo_flags = AG3S_RFO_CLR_BBRM;
+
+			/*
+			 * OFF system reset flags are set to prevent device from
+			 * auto powering on after jumping (via jump data). These
+			 * flags are lost on power loss, therefore should not
+			 * interfere with auto powering on.
+			 */
+			rfo_flags |= AG3S_RFO_SET_SYS;
+		}
+		break;
+	case EC_AFTER_G3_STATE_PREVIOUS:
+	default: /* Fallback to "Previous State" if state is invalid. */
+		/*
+		 * If device is off, then OFF reset flags are set, otherwise
+		 * these flags are unset. After power failure device will stay
+		 * off when power is reapplied, but only if it was off before
+		 * power was lost, otherwise it will auto power on.
+		 */
+		rfo_flags = (any_off ? AG3S_RFO_SET : AG3S_RFO_CLR);
+		break;
+	}
+
+update_reset_flags:
+	ag3s_update_off_reset_flags(rfo_flags);
+}
+
+static inline void ag3s_sync_reset_flags(void)
+{
+	ag3s_sync_on_hook(AG3S_SYNC_HOOK_NONE);
+}
+
+static int host_command_after_g3_state(struct host_cmd_handler_args *args)
+{
+	const struct ec_params_after_g3_state *p = args->params;
+	struct ec_response_after_g3_state *r = args->response;
+	enum ec_after_g3_state set_state = p->set_state;
+	int rv = EC_RES_SUCCESS;
+
+	if (set_state != EC_AFTER_G3_STATE_GET && !ag3s_set_state(set_state))
+		rv = EC_RES_ERROR;
+
+	r->cur_state = (uint8_t)(rv == EC_RES_SUCCESS ?
+			ag3s_get_state() : EC_AFTER_G3_STATE_ERROR);
+	args->response_size = sizeof(*r);
+
+	return rv;
+}
+DECLARE_HOST_COMMAND(EC_CMD_AFTER_G3_STATE, host_command_after_g3_state,
+		EC_VER_MASK(0));
+
+static int command_after_g3_state(int argc, char **argv)
+{
+	const char *state_name;
+
+	if (argc < 2) {
+		state_name = ag3s_get_state_name(ag3s_get_state());
+		if (!state_name)
+			return EC_ERROR_UNKNOWN;
+	} else if (argc == 2) {
+		enum ec_after_g3_state state = ag3s_find_state_by_name(argv[1]);
+		if (state == EC_AFTER_G3_STATE_UNKNOWN)
+			return EC_ERROR_PARAM1;
+		/* Normalize state name. */
+		state_name = ag3s_get_state_name(state);
+		if (!state_name || !ag3s_set_state(state))
+			return EC_ERROR_UNKNOWN;
+	} else {
+		return EC_ERROR_PARAM_COUNT;
+	}
+
+	ccprintf("%s: %s\n", ag3s_title, state_name);
+
+	return EC_SUCCESS;
+}
+DECLARE_CONSOLE_COMMAND(afterg3state, command_after_g3_state,
+		"[off|on|previous]",
+		"Set and/or get After G3 State value");
+
+/*
+ * Only use legacy code for handling OFF reset flags if CONFIG_AFTER_G3_STATE is
+ * not defined. This way any upstream changes affecting legacy code could still
+ * be merged, but will not be compiled, and will not affect After G3 State.
+ */
+#else /* !CONFIG_AFTER_G3_STATE */
+
 #ifdef CONFIG_POWER_BUTTON_INIT_IDLE
 /*
  * Set/clear AP_IDLE flag. It's set when the system gracefully shuts down and
@@ -148,6 +766,8 @@ DECLARE_HOOK(HOOK_CHIPSET_SHUTDOWN, pb_chipset_shutdown,
 	      */
 	     HOOK_PRIO_DEFAULT - 1);
 #endif
+
+#endif /* CONFIG_AFTER_G3_STATE */
 
 /**
  * Handle debounced power button changing state.

--- a/include/ec_commands.h
+++ b/include/ec_commands.h
@@ -5097,51 +5097,31 @@ struct __ec_align_size1 ec_params_charger_control {
 /*****************************************************************************/
 /* Custom MrChromebox commands: range 0x3AC0-0x3ACF */
 
-/*
- * NOTE: Before allocating new ID for a command, check if it is not used by
- * other boards in current coreboot ec_commands.h:
- *   https://github.com/MrChromebox/coreboot
- *   src/ec/google/chromeec/ec_commands.h
- */
-
-/* Set and/or get After G3 State value. */
-#define EC_CMD_AFTER_G3_STATE 0x3AC0
+/* Set After G3 State value. */
+#define EC_CMD_AFTER_G3_STATE_SET 0x3AC0
+/* Get After G3 State value. */
+#define EC_CMD_AFTER_G3_STATE_GET 0x3AC1
 
 enum ec_after_g3_state {
-	/* After restoring power device should always stay off. */
-	EC_AFTER_G3_STATE_OFF = 0,
-	/* After restoring power device should always auto power on. */
+	/* Reserved for unknown state. */
+	EC_AFTER_G3_STATE_UNKNOWN = -1,
+	/* Keep the device off when power is restored. */
+	EC_AFTER_G3_STATE_OFF,
+	/* Auto power on the device when power is restored. */
 	EC_AFTER_G3_STATE_ON,
 	/*
-	 * After restoring power device should only stay off if power was lost
-	 * after graceful shutdown, otherwise it should auto power on.
+	 * Keep the device off when power is restored only if it was gracefully
+	 * powered down prior to losing power, otherwise auto power it on.
 	 */
-	EC_AFTER_G3_STATE_PREVIOUS,
-
-	/* Special Values */
-
-	/* Make the command act as a getter only. */
-	EC_AFTER_G3_STATE_GET = 100,
-	/* Used for response only. Indicates internal command error. */
-	EC_AFTER_G3_STATE_ERROR,
-	/* Unknown state. */
-	EC_AFTER_G3_STATE_UNKNOWN
+	EC_AFTER_G3_STATE_PREVIOUS
 };
 
-struct __ec_align1 ec_params_after_g3_state {
-	/*
-	 * Set After G3 State value. Passing EC_AFTER_G3_STATE_GET makes the
-	 * command act as a getter only.
-	 */
-	uint8_t set_state; /* enum ec_after_g3_state */
+struct __ec_align1 ec_params_after_g3_state_set {
+	int8_t state; /* enum ec_after_g3_state */
 };
 
-struct __ec_align1 ec_response_after_g3_state {
-	/*
-	 * Current After G3 State value. EC_AFTER_G3_STATE_ERROR indicates
-	 * command failure to set/get value.
-	 */
-	uint8_t cur_state; /* enum ec_after_g3_state */
+struct __ec_align1 ec_response_after_g3_state_get {
+	int8_t state; /* enum ec_after_g3_state */
 };
 
 /*****************************************************************************/

--- a/include/ec_commands.h
+++ b/include/ec_commands.h
@@ -5108,10 +5108,8 @@ struct __ec_align_size1 ec_params_charger_control {
 #define EC_CMD_AFTER_G3_STATE 0x3AC0
 
 enum ec_after_g3_state {
-	/* Unknown state. */
-	EC_AFTER_G3_STATE_UNKNOWN = 0,
 	/* After restoring power device should always stay off. */
-	EC_AFTER_G3_STATE_OFF,
+	EC_AFTER_G3_STATE_OFF = 0,
 	/* After restoring power device should always auto power on. */
 	EC_AFTER_G3_STATE_ON,
 	/*
@@ -5125,7 +5123,9 @@ enum ec_after_g3_state {
 	/* Make the command act as a getter only. */
 	EC_AFTER_G3_STATE_GET = 100,
 	/* Used for response only. Indicates internal command error. */
-	EC_AFTER_G3_STATE_ERROR
+	EC_AFTER_G3_STATE_ERROR,
+	/* Unknown state. */
+	EC_AFTER_G3_STATE_UNKNOWN
 };
 
 struct __ec_align1 ec_params_after_g3_state {

--- a/include/ec_commands.h
+++ b/include/ec_commands.h
@@ -5095,6 +5095,56 @@ struct __ec_align_size1 ec_params_charger_control {
 };
 
 /*****************************************************************************/
+/* Custom MrChromebox commands: range 0x3AC0-0x3ACF */
+
+/*
+ * NOTE: Before allocating new ID for a command, check if it is not used by
+ * other boards in current coreboot ec_commands.h:
+ *   https://github.com/MrChromebox/coreboot
+ *   src/ec/google/chromeec/ec_commands.h
+ */
+
+/* Set and/or get After G3 State value. */
+#define EC_CMD_AFTER_G3_STATE 0x3AC0
+
+enum ec_after_g3_state {
+	/* Unknown state. */
+	EC_AFTER_G3_STATE_UNKNOWN = 0,
+	/* After restoring power device should always stay off. */
+	EC_AFTER_G3_STATE_OFF,
+	/* After restoring power device should always auto power on. */
+	EC_AFTER_G3_STATE_ON,
+	/*
+	 * After restoring power device should only stay off if power was lost
+	 * after graceful shutdown, otherwise it should auto power on.
+	 */
+	EC_AFTER_G3_STATE_PREVIOUS,
+
+	/* Special Values */
+
+	/* Make the command act as a getter only. */
+	EC_AFTER_G3_STATE_GET = 100,
+	/* Used for response only. Indicates internal command error. */
+	EC_AFTER_G3_STATE_ERROR
+};
+
+struct __ec_align1 ec_params_after_g3_state {
+	/*
+	 * Set After G3 State value. Passing EC_AFTER_G3_STATE_GET makes the
+	 * command act as a getter only.
+	 */
+	uint8_t set_state; /* enum ec_after_g3_state */
+};
+
+struct __ec_align1 ec_response_after_g3_state {
+	/*
+	 * Current After G3 State value. EC_AFTER_G3_STATE_ERROR indicates
+	 * command failure to set/get value.
+	 */
+	uint8_t cur_state; /* enum ec_after_g3_state */
+};
+
+/*****************************************************************************/
 /*
  * Reserve a range of host commands for board-specific, experimental, or
  * special purpose features. These can be (re)used without updating this file.

--- a/util/ectool.c
+++ b/util/ectool.c
@@ -49,7 +49,7 @@ static struct option long_opts[] = {
 const char help_str[] =
 	"Commands:\n"
 	"  afterg3state [off|on|previous]\n"
-	"      Set and/or get After G3 State value\n"
+	"      Set or get After G3 State value\n"
 	"  apreset\n"
 	"      Issue AP reset\n"
 	"  autofanctrl <on>\n"
@@ -1224,17 +1224,14 @@ int cmd_apreset(int argc, char *argv[])
 	return ec_command(EC_CMD_AP_RESET, 0, NULL, 0, NULL, 0);
 }
 
-/*
- * Order should match enum ec_after_g3_state, starting from value 0.
- * Special values are excluded.
- */
+/* Order should match enum ec_after_g3_state, starting from value 0. */
 static const char *ag3s_name_table[] = { "off", "on", "previous" };
 
 static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
 {
 	return ((state >= EC_AFTER_G3_STATE_OFF &&
-	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
-			ag3s_name_table[state] : NULL);
+		 state <= EC_AFTER_G3_STATE_PREVIOUS) ?
+		ag3s_name_table[state] : NULL);
 }
 
 static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
@@ -1247,35 +1244,45 @@ static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
 	return EC_AFTER_G3_STATE_UNKNOWN;
 }
 
-int cmd_afterg3state(int argc, char *argv[])
+int cmd_after_g3_state(int argc, char *argv[])
 {
 	static const char *ag3s_title = "After G3 State";
 
-	struct ec_params_after_g3_state p;
-	struct ec_response_after_g3_state r;
+	enum ec_after_g3_state state;
 	const char *state_name;
 	int rv;
 
 	if (argc < 2) {
-		p.set_state = (uint8_t)EC_AFTER_G3_STATE_GET;
+		struct ec_response_after_g3_state_get r;
+
+		rv = ec_command(EC_CMD_AFTER_G3_STATE_GET, 0, NULL, 0, &r,
+				sizeof(r));
+		if (rv < 0)
+			return -1;
+
+		state = r.state;
 	} else if (argc == 2) {
-		enum ec_after_g3_state state = ag3s_find_state_by_name(argv[1]);
+		struct ec_params_after_g3_state_set p;
+
+		state = ag3s_find_state_by_name(argv[1]);
 		if (state == EC_AFTER_G3_STATE_UNKNOWN) {
 			fprintf(stderr, "%s: Invalid state '%s'\n", ag3s_title,
-					argv[1]);
+				argv[1]);
 			return -1;
 		}
-		p.set_state = (uint8_t)state;
+
+		p.state = (int8_t)state;
+
+		rv = ec_command(EC_CMD_AFTER_G3_STATE_SET, 0, &p, sizeof(p),
+				NULL, 0);
+		if (rv < 0)
+			return -1;
 	} else {
 		fprintf(stderr, "%s: Too many args\n", ag3s_title);
 		return -1;
 	}
 
-	rv = ec_command(EC_CMD_AFTER_G3_STATE, 0, &p, sizeof(p), &r, sizeof(r));
-	if (rv < 0 || r.cur_state == EC_AFTER_G3_STATE_ERROR)
-		return -1;
-
-	state_name = ag3s_get_state_name(r.cur_state);
+	state_name = ag3s_get_state_name(state);
 	if (!state_name)
 		return -1;
 
@@ -8112,7 +8119,7 @@ int cmd_cec(int argc, char *argv[])
 
 /* NULL-terminated list of commands */
 const struct command commands[] = {
-	{"afterg3state", cmd_afterg3state},
+	{"afterg3state", cmd_after_g3_state},
 	{"apreset", cmd_apreset},
 	{"autofanctrl", cmd_thermal_auto_fan_ctrl},
 	{"backlight", cmd_lcd_backlight},

--- a/util/ectool.c
+++ b/util/ectool.c
@@ -49,7 +49,7 @@ static struct option long_opts[] = {
 const char help_str[] =
 	"Commands:\n"
 	"  afterg3state [off|on|previous]\n"
-	"      Set or get After G3 State value\n"
+	"      Get or set After G3 State value\n"
 	"  apreset\n"
 	"      Issue AP reset\n"
 	"  autofanctrl <on>\n"

--- a/util/ectool.c
+++ b/util/ectool.c
@@ -48,6 +48,8 @@ static struct option long_opts[] = {
 
 const char help_str[] =
 	"Commands:\n"
+	"  afterg3state [off|on|previous]\n"
+	"      Set and/or get After G3 State value\n"
 	"  apreset\n"
 	"      Issue AP reset\n"
 	"  autofanctrl <on>\n"
@@ -1220,6 +1222,66 @@ int cmd_rwsig_action(int argc, char *argv[])
 int cmd_apreset(int argc, char *argv[])
 {
 	return ec_command(EC_CMD_AP_RESET, 0, NULL, 0, NULL, 0);
+}
+
+/*
+ * Order should match enum ec_after_g3_state, starting from value 1.
+ * Special values are excluded.
+ */
+static const char *ag3s_name_table[] = { "off", "on", "previous" };
+
+static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
+{
+	return ((state >= EC_AFTER_G3_STATE_OFF &&
+	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
+			ag3s_name_table[state - 1] : NULL);
+}
+
+static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
+{
+	int i, len;
+	for (i = 0, len = ARRAY_SIZE(ag3s_name_table); i < len; ++i) {
+		if (!strcasecmp(name, ag3s_name_table[i]))
+			return i + 1;
+	}
+	return EC_AFTER_G3_STATE_UNKNOWN;
+}
+
+int cmd_afterg3state(int argc, char *argv[])
+{
+	static const char *ag3s_title = "After G3 State";
+
+	struct ec_params_after_g3_state p;
+	struct ec_response_after_g3_state r;
+	const char *state_name;
+	int rv;
+
+	if (argc < 2) {
+		p.set_state = (uint8_t)EC_AFTER_G3_STATE_GET;
+	} else if (argc == 2) {
+		enum ec_after_g3_state state = ag3s_find_state_by_name(argv[1]);
+		if (state == EC_AFTER_G3_STATE_UNKNOWN) {
+			fprintf(stderr, "%s: Invalid state '%s'\n", ag3s_title,
+					argv[1]);
+			return -1;
+		}
+		p.set_state = (uint8_t)state;
+	} else {
+		fprintf(stderr, "%s: Too many args\n", ag3s_title);
+		return -1;
+	}
+
+	rv = ec_command(EC_CMD_AFTER_G3_STATE, 0, &p, sizeof(p), &r, sizeof(r));
+	if (rv < 0 || r.cur_state == EC_AFTER_G3_STATE_ERROR)
+		return -1;
+
+	state_name = ag3s_get_state_name(r.cur_state);
+	if (!state_name)
+		return -1;
+
+	printf("%s: %s\n", ag3s_title, state_name);
+
+	return 0;
 }
 
 static void *fp_download_frame(struct ec_response_fp_info *info, int all)
@@ -8050,6 +8112,7 @@ int cmd_cec(int argc, char *argv[])
 
 /* NULL-terminated list of commands */
 const struct command commands[] = {
+	{"afterg3state", cmd_afterg3state},
 	{"apreset", cmd_apreset},
 	{"autofanctrl", cmd_thermal_auto_fan_ctrl},
 	{"backlight", cmd_lcd_backlight},

--- a/util/ectool.c
+++ b/util/ectool.c
@@ -1225,7 +1225,7 @@ int cmd_apreset(int argc, char *argv[])
 }
 
 /*
- * Order should match enum ec_after_g3_state, starting from value 1.
+ * Order should match enum ec_after_g3_state, starting from value 0.
  * Special values are excluded.
  */
 static const char *ag3s_name_table[] = { "off", "on", "previous" };
@@ -1234,7 +1234,7 @@ static inline const char *ag3s_get_state_name(enum ec_after_g3_state state)
 {
 	return ((state >= EC_AFTER_G3_STATE_OFF &&
 	         state <= EC_AFTER_G3_STATE_PREVIOUS) ?
-			ag3s_name_table[state - 1] : NULL);
+			ag3s_name_table[state] : NULL);
 }
 
 static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
@@ -1242,7 +1242,7 @@ static enum ec_after_g3_state ag3s_find_state_by_name(const char *name)
 	int i, len;
 	for (i = 0, len = ARRAY_SIZE(ag3s_name_table); i < len; ++i) {
 		if (!strcasecmp(name, ag3s_name_table[i]))
-			return i + 1;
+			return i;
 	}
 	return EC_AFTER_G3_STATE_UNKNOWN;
 }


### PR DESCRIPTION
After G3 State, which can be selectively enabled/customized, allows changing ChromeEC after G3 behavior at run-time via console, ectool, and host command.

Without this, ChromeEC will always use default compiled after G3 behavior (usually "Previous State"), overriding coreboot CFR.

Coreboot can use this to apply user selected after G3 behavior (CFR) to ChromeEC at boot.

Tested on FIZZ/SION.

- Set to `S0` - always auto powers up, graceful shutdown or not.
- Set to `S5` - always stays off, even if power was lost while device was running.
- Set to `Previous State` - auto powers up only if shutdown was not graceful.

Just to keep a note - depleted (or missing) 3V coin battery, which sustains bbram used to store OFF flag, will always make device auto power up when power is restored. This is a hard limitation, and changing this would require messing with EC RO area.

This should fix the following issues (requires coreboot patch to make use of this new command, separate PR):
https://github.com/MrChromebox/firmware/issues/766
https://github.com/MrChromebox/firmware/issues/669
https://github.com/MrChromebox/firmware/issues/831

This also should make FIZZ EC variant `firmware-fizz-10139.B-auto_on` obsolete.